### PR TITLE
Extract citing summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Which would then produce output similar to
                  {'names': 'Boris', 'surname': 'Klempa'},
                  {'names': 'Jozef', 'surname': 'Nosek'},
                  {'names': 'Tomas', 'surname': 'Vinar'}],
+     'citing_summary': ['WOS:000718302600032', 'WOS:000707419500038'],
      'eissn': '1572-994X',
      'issn': '0920-8569',
      'issue': '6',
@@ -41,7 +42,7 @@ Which would then produce output similar to
      'pubdate': 'DEC 2021',
      'publisher': 'SPRINGER, VAN GODEWIJCKSTRAAT 30, 3311 GZ DORDRECHT, '
                   'NETHERLANDS',
-     'times_cited': '1',
+     'times_cited': '2',
      'title': 'A SARS-CoV-2 mutant from B.1.258 lineage with increment H69/ '
               'increment V70 deletion in the Spike protein circulating in Central '
               'Europe in the fall 2020',
@@ -51,7 +52,7 @@ Which would then produce output similar to
 To debug how the script works (i.e. by not making the Chromium that's being
 started headless), you can specify the `--debug` option.
 
-Shuld you want to make use of a proxy, e.g. SOCKS proxy running on port `11000`
+Should you want to make use of a proxy, e.g. SOCKS proxy running on port `11000`
 on `localhost`, you can do so by specifying further options:
 
     python extract-wos-article.py https://www.webofscience.com/wos/woscc/full-record/WOS:000690353600001 --debug --proxy-server socks://localhost:11000

--- a/extract-wos-article.py
+++ b/extract-wos-article.py
@@ -50,7 +50,7 @@ async def extract_citing_summary(page: Page, article_id: str):
     final_page_num = int(final_page_text.strip())
 
     articles = []
-    while True:
+    while curr_page_num <= final_page_num:
         curr_articles_num = -1
         curr_articles = []
 
@@ -60,14 +60,11 @@ async def extract_citing_summary(page: Page, article_id: str):
             curr_articles = await page.query_selector_all(CITING_SELECTORS["citations_articles"])
             time.sleep(0.1)
 
-        articles.extend(curr_articles)
-
         if curr_page_num < final_page_num:
             await page.click('[aria-label="Bottom Next Page"]')
             time.sleep(2)
-        if curr_page_num == final_page_num:
-            break
 
+        articles.extend(curr_articles)
         curr_page_num += 1
 
     articles_ids = []

--- a/extract-wos-article.py
+++ b/extract-wos-article.py
@@ -34,11 +34,11 @@ REGEX = {
     "year": re.compile(".*([0-9]{4})"),
     "wos_id": re.compile("(WOS:[0-9]{15})"),
 }
-CITING_SUMMARY_URL_PREFIX = "https://www.webofscience.com/wos/woscc/citing-summary/"
+CITING_SUMMARY_URL_PREFIX = "https://www.webofscience.com/wos/woscc/citing-summary"
 
 
 async def extract_citing_summary(page: Page, article_id: str):
-    url = f"{CITING_SUMMARY_URL_PREFIX}{article_id}"
+    url = f"{CITING_SUMMARY_URL_PREFIX}/{article_id}"
     await page.goto(url, wait_until="networkidle")
 
     curr_page = await page.query_selector(CITING_SELECTORS["current_page"])

--- a/extract-wos-article.py
+++ b/extract-wos-article.py
@@ -38,7 +38,7 @@ CITING_SUMMARY_URL_PREFIX = "https://www.webofscience.com/wos/woscc/citing-summa
 
 
 async def extract_citing_summary(page: Page, article_id: str):
-    url = CITING_SUMMARY_URL_PREFIX + article_id
+    url = f"{CITING_SUMMARY_URL_PREFIX}{article_id}"
     await page.goto(url, wait_until="networkidle")
 
     curr_page = await page.query_selector(CITING_SELECTORS["current_page"])

--- a/extract-wos-article.py
+++ b/extract-wos-article.py
@@ -32,7 +32,7 @@ JOURNAL_SELECTORS_MAPPING = {
 
 REGEX = {
     "year": re.compile(".*([0-9]{4})"),
-    "wos_id_number": re.compile("([0-9]{15})"),
+    "wos_id": re.compile("(WOS:[0-9]{15})"),
 }
 CITING_SUMMARY_URL_PREFIX = "https://www.webofscience.com/wos/woscc/citing-summary/"
 
@@ -73,8 +73,8 @@ async def extract_citing_summary(page: Page, article_id: str):
     articles_ids = []
     for article in articles:
         article_text = await article.inner_html()
-        article_id = REGEX["wos_id_number"].findall(article_text)[0]
-        articles_ids.append(f"WOS:{article_id}")
+        article_id = REGEX["wos_id"].findall(article_text)[0]
+        articles_ids.append(article_id)
     return articles_ids
 
 

--- a/extract-wos-article.py
+++ b/extract-wos-article.py
@@ -57,9 +57,7 @@ async def extract_citing_summary(page: Page, article_id: str):
         while len(curr_articles) > curr_articles_num:
             curr_articles_num = len(curr_articles)
             await page.keyboard.press("PageDown")
-            curr_articles = await page.query_selector_all(
-                CITING_SELECTORS["citations_articles"]
-            )
+            curr_articles = await page.query_selector_all(CITING_SELECTORS["citations_articles"])
             time.sleep(0.1)
 
         articles.extend(curr_articles)
@@ -80,9 +78,7 @@ async def extract_citing_summary(page: Page, article_id: str):
     return articles_ids
 
 
-async def extract_text_from_selector(
-    selector: str, page: Page, default_value: str = ""
-):
+async def extract_text_from_selector(selector: str, page: Page, default_value: str = ""):
     selector = await page.query_selector(selector)
     if not selector:
         return default_value
@@ -161,9 +157,7 @@ async def main_extract(url: str, debug: bool = False, proxy_server: str = ""):
         await browser.close()
 
 
-def main(
-    url: str, debug: bool = typer.Option(False), proxy_server: str = typer.Option("")
-):
+def main(url: str, debug: bool = typer.Option(False), proxy_server: str = typer.Option("")):
     asyncio.run(main_extract(url, debug, proxy_server))
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[tool.black]
+line-length = 100

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,10 +3,10 @@ click==8.0.3
 greenlet==1.1.2
 importlib-metadata==4.8.2
 msgpack==1.0.3
-playwright==1.17.0
+playwright==1.17.2
 pre-commit==2.16.0
 pyee==8.2.2
 typer==0.4.0
-typing_extensions==4.0.0
+typing_extensions==4.0.1
 websockets==10.1
 zipp==3.6.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 black==21.12b0
 click==8.0.3
 greenlet==1.1.2
-importlib-metadata==4.8.2
+importlib-metadata==4.10.0
 msgpack==1.0.3
 playwright==1.17.2
 pre-commit==2.16.0


### PR DESCRIPTION
Close #2 

- extract list of all citations for specified article
- there is a hack with pushing the `PageDown` button, because there is some sort of JS that loads the html data as you move down the page. without scrolling through all of the 'citation articles', the script would always extract only the first two articles
- there is a maximum of 50 articles per page so we check all of the pages, not just the first one